### PR TITLE
Add API authentication and fix route loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.streamlit/secrets.toml

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ import humanize
 import altair as alt
 import pandas as pd
 
-from seats_aero.api import Availability, PARTNERS, partner_to_display_name
+from seats_aero.api import Availability, PARTNERS, partner_to_display_name, Route
 from seats_aero.plot import get_route_df
 from seats_aero.airport import city_expansion_dict, country_expansion_dict
 from datetime import datetime as time
@@ -23,14 +23,16 @@ with st.sidebar:
         "Partners",
         PARTNERS,
         format_func=partner_to_display_name,
-        index=PARTNERS.index("lifemiles"),
+        index=PARTNERS.index("aeroplan"),
         label_visibility="hidden",
     )
 
 
 @st.cache_data(ttl=timedelta(minutes=15))
 def load_availabilities(partner: str) -> Tuple[List[Availability], datetime]:
-    return Availability.fetch(partner), time.now()
+    routes = Route.fetch()
+    route_map = {r.id: r for r in routes}
+    return Availability.fetch(route_map, partner), time.now()
 
 
 st.title("✈️Seats.areo Availability Visualizer")

--- a/seats_aero/api.py
+++ b/seats_aero/api.py
@@ -8,7 +8,7 @@ from streamlit import secrets
 import requests
 
 PARTNERS = [
-    "lifemiles",
+    "aeroplan",
     "aeromexico",
     "american",
     "united",
@@ -20,7 +20,7 @@ PARTNERS = [
 
 def partner_to_display_name(partner: str) -> str:
     return {
-        "lifemiles": "LifeMiles",
+        "aeroplan": "Aeroplan",
         "aeromexico": "Aeromexico",
         "american": "American Airlines",
         "united": "United Airlines",
@@ -176,12 +176,12 @@ class Availability:
         return res
 
     @staticmethod
-    def from_dict(d: Dict) -> "Availability":
+    def from_dict(d: Dict, route_map: dict[str, Route]) -> "Availability":
         raw = d
         return Availability(
             id=raw["ID"],
             route_id=raw["RouteID"],
-            route=Route.from_dict(raw["Route"]),
+            route=route_map[raw["RouteID"]],
             date=raw["Date"],
             # parse from 2023-05-24T00:00:00Z to datetime
             parsed_date=datetime.strptime(raw["ParsedDate"], "%Y-%m-%dT%H:%M:%SZ"),
@@ -214,14 +214,14 @@ class Availability:
         return Availability.from_dict(json.loads(json_str))
 
     @staticmethod
-    def fetch(partner: str = "lifemiles") -> List["Availability"]:
+    def fetch(route_map: dict[str, Route], partner: str = "aeroplan") -> List["Availability"]:
         url = f"https://seats.aero/api/availability?source={partner}"
         response = requests.get(url, headers={
             "Partner-Authorization": secrets["api_key"]
         })
         all_availabilities = json.loads(response.text)
         return [
-            Availability.from_dict(availability) for availability in all_availabilities
+            Availability.from_dict(availability, route_map) for availability in all_availabilities
         ]
 
     def airline_str(self) -> str:

--- a/seats_aero/api.py
+++ b/seats_aero/api.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from functools import lru_cache
 from typing import Dict, List, Set
+from streamlit import secrets
 
 import requests
 
@@ -62,7 +63,9 @@ class Route:
     @staticmethod
     def fetch() -> List["Route"]:
         url = "https://seats.aero/api/routes"
-        response = requests.get(url)
+        response = requests.get(url, headers={
+            "Partner-Authorization": secrets["api_key"]
+        })
         all_routes = json.loads(response.text)
         return [Route.from_dict(route) for route in all_routes]
 
@@ -213,7 +216,9 @@ class Availability:
     @staticmethod
     def fetch(partner: str = "lifemiles") -> List["Availability"]:
         url = f"https://seats.aero/api/availability?source={partner}"
-        response = requests.get(url)
+        response = requests.get(url, headers={
+            "Partner-Authorization": secrets["api_key"]
+        })
         all_availabilities = json.loads(response.text)
         return [
             Availability.from_dict(availability) for availability in all_availabilities


### PR DESCRIPTION
The Seats.aero API now requires authentication, which broke this project. Additionally, the `Route` object is no longer hydrated, so it needs to be loaded first from the Routes API and then accessed this way.

To add an API key, create `.streamlit/secrets.toml` with [your API key](https://seats.aero/apikey) in the following file:

```
api_key = "pro_xxx"
```